### PR TITLE
Fix syntax errors:  add closing `})` in  `context`s

### DIFF
--- a/cypress/Integration/glossary/glossary_default_spec.js
+++ b/cypress/Integration/glossary/glossary_default_spec.js
@@ -38,3 +38,4 @@ context('Glossary default test', function(){
   it('Verifies that predefined words are visible in glossary', () => {
     cy.get('.sidebar-content').should('not.have.value', 'Words I Have Defined');
   })
+})

--- a/cypress/Integration/glossary/glossary_icons_spec.js
+++ b/cypress/Integration/glossary/glossary_icons_spec.js
@@ -24,3 +24,4 @@ context('Glossary Icon Test', function(){
     cy.get('.definition--caption--2GD2UvrL').should('be.visible');
     cy.get('.sidebar-hdr').click()
   })
+})


### PR DESCRIPTION
@eireland @kevinsantos-cc -- Here is a minor fix.

It was fun trying this out.  Thanks for starting this work.

You guys should coordinate with Piotr to add some better cypress selectors.
