### PR TITLE
188754675 Add Activity Title Checks in Cypress Tests

### DIFF
--- a/cypress/e2e/activity-sequence-settings/activity-settings-notebook-layout.cy.js
+++ b/cypress/e2e/activity-sequence-settings/activity-settings-notebook-layout.cy.js
@@ -13,6 +13,9 @@ const url = {
 function previewTest() {
   cy.visit("");
   authoringPage.previewActivity("Test Automation Create Activity Notebook Layout");
+  // to-do: add the data-testid='activity-title' attribute once on staging
+  cy.contains('div', 'Test Automation Create Activity Notebook Layout') // Finds a div containing the exact text
+      .should('be.visible'); // Ensures the element is visible
 }
 
 context("Test Activity Setting Notebook Layout", () => {

--- a/cypress/e2e/activity-sequence-settings/activity-settings.cy.js
+++ b/cypress/e2e/activity-sequence-settings/activity-settings.cy.js
@@ -30,8 +30,11 @@ context("Test Activity Settings", () => {
       settingsPage.getSaveButton().click();
       cy.wait(2000);
       settingsPage.getSettingsPage().should("exist");
+      //to-do: add more thorough check with data-testid tags (PT-#188775242)
+      cy.get('h1').contains('Edit Activity: Test Automation Activity Settings').should('exist');
     });
     it("Activity Settings", () => {
+      cy.get('h1').contains('Edit Activity: Test Automation Activity Settings').should('exist');
       settingsPage.getGlossaryDropDown().should("be.enabled");
       settingsPage.getBackgroundImageUrl().type(url.imageUrl);
       settingsPage.getPreviewImageUrl().type(url.imageUrl);

--- a/cypress/e2e/activity-sequence-settings/hide-question-numbers-setting.cy.js
+++ b/cypress/e2e/activity-sequence-settings/hide-question-numbers-setting.cy.js
@@ -32,6 +32,8 @@ context("Test hide question number setting in activity and sequence", () => {
       settingsPage.getActivityName().type(name.activity);
       settingsPage.getSaveButton().click();
       settingsPage.getSettingsPage().should("exist");
+      // to-do: add more thorough check with data-testid tags (PT-#188775242)
+      cy.get('h1').contains('Test Hide Question Numbers Activity').should('exist');
       settingsPage.getHideQuestionNumbersCheckbox().should("exist");
       settingsPage.verifyHideQuestionNumbersLabel(name.label);
       settingsPage.verifyHideQuestionNumbersHint(name.activityHint);
@@ -45,6 +47,8 @@ context("Test hide question number setting in activity and sequence", () => {
       beforeTestSequence(name.sequence);
       settingsPage.getCreateSequenceButton().click();
       settingsPage.getSettingsPage().should("exist");
+      // to-do: add more thorough check with data-testid tags (PT-#188775242)
+      cy.get('span.title').contains('Edit sequence').should('exist');
       settingsPage.getSeqTitle().type(name.sequence);
       settingsPage.getSequenceHideQuestionNumbersCheckbox().should("exist");
       settingsPage.verifySequenceHideQuestionNumbersLabel(name.label);

--- a/cypress/support/activity-sequence-settings.cy.js
+++ b/cypress/support/activity-sequence-settings.cy.js
@@ -1,4 +1,5 @@
 class ActivitySequenceSettingsPage {
+  // to-do: add data-testid tags to the elements (PT-#188775242)
   getCreateActivityButton() {
     return cy.get('#content .top-header .buttons-menu a').eq(0);
   }

--- a/cypress/support/authoring-page.cy.js
+++ b/cypress/support/authoring-page.cy.js
@@ -516,13 +516,25 @@ class AuthoringPage {
   launchActivity(name) {
     cy.log("Launch Test Activity : ");
     // to-do: add data-test ID once on staging PT-#188775242
-    cy.get("#search input").eq(0).type(name);
-    cy.get("#search input").eq(1).click();
+    cy.get("#search input").eq(0).type(name); // Type the activity name in the search bar
+    cy.get("#search input").eq(1).click(); // Click the search button
     cy.wait(500);
-    cy.get(".action_menu_header_right .edit a").click();
+    cy.get(".action_menu_header_right .edit a").click(); // Click "Edit" link in the action menu
     cy.wait(500);
-    cy.get('#rightcol #pages [id^=item_interactive_page] .edit').click();
+    cy.get('#rightcol #pages [id^=item_interactive_page] .edit').click(); // Open the interactive page for editing
     cy.wait(2000);
+  
+    // Assert that the activity title exists and matches the provided name
+    cy.get('.activity-title') 
+      .should('exist') // Ensure the title exists
+      .and('be.visible') // Ensure the title is visible
+      .and('have.text', name); // Check that the title text matches the activity name passed in
+  
+    // Additional assertion example for finding text directly using the variable
+    cy.contains('div', name) 
+      .should('be.visible'); // Ensures the div containing the text is visible
+  
+    // to-do: replace selectors with `data-testid` once available in staging
   }
   deleteActivity(name) {
     cy.log("Delete Test Activity : ");

--- a/cypress/support/authoring-page.cy.js
+++ b/cypress/support/authoring-page.cy.js
@@ -497,6 +497,7 @@ class AuthoringPage {
   //***************************************************************************************************************
   previewActivity(name) {
     cy.log("Launch Test Activity : ");
+    // to-do: add data-test ID once on staging PT-#188775242
     cy.get("#search input").eq(0).type(name);
     cy.get("#search input").eq(1).click();
     cy.wait(1000);
@@ -505,6 +506,7 @@ class AuthoringPage {
   }
   previewSequence(name) {
     cy.log("Launch Test Sequence : ");
+    // to-do: add data-test ID once on staging PT-#188775242
     cy.get("#search input").eq(0).type(name);
     cy.get("#search input").eq(1).click();
     cy.wait(1000);
@@ -513,6 +515,7 @@ class AuthoringPage {
   }
   launchActivity(name) {
     cy.log("Launch Test Activity : ");
+    // to-do: add data-test ID once on staging PT-#188775242
     cy.get("#search input").eq(0).type(name);
     cy.get("#search input").eq(1).click();
     cy.wait(500);
@@ -523,6 +526,7 @@ class AuthoringPage {
   }
   deleteActivity(name) {
     cy.log("Delete Test Activity : ");
+    // to-do: add data-test ID once on staging PT-#188775242
     cy.get("#search input").eq(0).type(name);
     cy.get("#search input").eq(1).click();
     cy.wait(1000);
@@ -540,6 +544,7 @@ class AuthoringPage {
   }
   deleteSequence(name) {
     cy.log("Delete Test Sequence : ");
+    // to-do: add data-test ID once on staging PT-#188775242
     cy.get("#search input").eq(0).type(name);
     cy.get("#search input").eq(1).click();
     cy.wait(1000);


### PR DESCRIPTION
[PT-188754675](https://www.pivotaltracker.com/story/show/188754675)

### Description:

This PR adds checks to confirm the correct activity is launched by matching the activity name. Once data-testid tags from [LARA PR #1205](https://github.com/concord-consortium/lara/pull/1205/) are live on staging, the tests will be updated to use those tags for better selectors.

### Changes:
- Added assertions to check that the activity title exists, is visible, and matches the expected name.
- Added comments to update selectors once data-testid tags are available.

### Reviewer:

@emcelroy - please review. Let me know if any changes are needed!